### PR TITLE
Set up ability to have a subdomain

### DIFF
--- a/lib/tbe_elixir_web/controllers/subdomain/page_controller.ex
+++ b/lib/tbe_elixir_web/controllers/subdomain/page_controller.ex
@@ -1,0 +1,8 @@
+defmodule TbeElixirWeb.Subdomain.PageController do
+  use TbeElixirWeb, :controller
+
+  def index(conn, _params) do
+    text(conn, "Subdomain home page for #{conn.private[:subdomain]}")
+  end
+
+end

--- a/lib/tbe_elixir_web/endpoint.ex
+++ b/lib/tbe_elixir_web/endpoint.ex
@@ -38,6 +38,7 @@ defmodule TbeElixirWeb.Endpoint do
     key: "_tbe_elixir_key",
     signing_salt: "A3nOQCCC"
 
+  plug TbeElixirWeb.Plug.Subdomain, TbeElixirWeb.SubdomainRouter
   plug TbeElixirWeb.Router
 
   @doc """

--- a/lib/tbe_elixir_web/plugs/subdomain.ex
+++ b/lib/tbe_elixir_web/plugs/subdomain.ex
@@ -1,0 +1,23 @@
+defmodule TbeElixirWeb.Plug.Subdomain do
+  import Plug.Conn
+
+  @doc false
+  def init(default), do: default
+
+  @doc false
+  def call(conn, router) do
+    case get_subdomain(conn.host) do
+      subdomain when byte_size(subdomain) > 0 ->
+        conn
+        |> put_private(:subdomain, subdomain)
+        |> router.call(router.init({}))
+        |> halt
+        _-> conn
+    end
+  end
+
+  defp get_subdomain(host) do
+    root_host = TbeElixirWeb.Endpoint.config(:url)[:host]
+    String.replace(host, ~r/.?#{root_host}/, "")
+  end
+end

--- a/lib/tbe_elixir_web/subdomain_router.ex
+++ b/lib/tbe_elixir_web/subdomain_router.ex
@@ -1,0 +1,17 @@
+defmodule TbeElixirWeb.SubdomainRouter do
+  use TbeElixirWeb, :router
+
+  pipeline :browser do
+    plug :accepts, ["html"]
+    plug :fetch_session
+    plug :fetch_flash
+    plug :protect_from_forgery
+    plug :put_secure_browser_headers
+  end
+
+  scope "/", TbeElixirWeb.Subdomain do
+    pipe_through :browser # Use the default browser stack
+
+    get "/", PageController, :index
+  end
+end


### PR DESCRIPTION
Set up the basics to have a subdomain point to a different page. The purpose of this will be to have a TIL subdomain similar to https://til.hashrocket.com. There are many times I learn small little things and I want a way to have them easily referenced. This will save me a lot of post-it notes stuck to my monitor.

A good example of this being useful is when for a different project I had an error that stated `(Postgrex.Error) ERROR 42P07 (duplicate_table): relation already exists` when I ran my tests. I have had this error before but couldn't quit remember the solution (the test database needed to be reset in my case). If I had my own TIL section, I could have found the solution again quicker.